### PR TITLE
Add new page : Download Next

### DIFF
--- a/src/pages/next.js
+++ b/src/pages/next.js
@@ -4,7 +4,7 @@ import App from '../components/layout/App';
 import Seo from '../components/molecules/Seo';
 import SectionFullPage from '../components/molecules/SectionFullPage';
 
-const NotFoundPage = props => {
+const DownloadNextPage = props => {
   const DATA = props.data.content.data;
   return (
     <App headerTheme="dark">
@@ -34,10 +34,10 @@ const NotFoundPage = props => {
     </App>
   );
 };
-export default NotFoundPage;
+export default DownloadNextPage;
 export const pageQuery = graphql`
-  query notFoundQuery {
-    content: prismic404(id: { eq: "Prismic__404__XBYOSxEAANRffCOr" }) {
+  query downloadNextQuery {
+    content: prismic404(id: { eq: "Prismic__404__XKxhBhAAACMANvTB" }) {
       data {
         title
         subtitle {


### PR DESCRIPTION
## What is this PR
It adds a new page to download Station Next build.

## How does it work
After creating a new page in Prismic (based on the 404 template), it adds a full new page based on the same code as the 404. The relevant queries have been updated to match the different pages.

## Tests
- [ ] Start the website
- [ ] Check that the url : `/next` lead to the download next page
- [ ] Check that a non existing url (`/not-existing`) still leads to the correct 404